### PR TITLE
fix: shorten name

### DIFF
--- a/callisto-theme.json
+++ b/callisto-theme.json
@@ -1,6 +1,6 @@
 {
   "identifier": "com.aliciasykes.aht-theme",
-  "name": "Callisto Theme for StandardNotes",
+  "name": "Callisto Theme",
   "content_type": "SN|Theme",
   "version": "1.0.0",
   "description": "Dusty background with teal accents",


### PR DESCRIPTION
On the mobile app it says "Callisto Theme for Standard Notes" instead of just "Callisto Theme".