### PR TITLE
Switching all of the internal links back to Lissy93/callisto-theme-standard-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 <p align="center"><i>Dusty navy (<code>#0B1021</code>) and teal (<code>#00CCB4</code>) theme for <a href="https://standardnotes.org/">Standard Notes</a></i></p>
 
 <p align="center">
-  <img src="https://github.com/xthursdayx/callisto-theme-standard-notes/blob/master/screenshot1.png"
+  <img src="https://github.com/Lissy93/callisto-theme-standard-notes/blob/master/screenshot1.png"
     alt="Screenshot"
     title="Screenshot"
   />
 </p>
 
 <p align="center">
-  <img src="https://github.com/xthursdayx/callisto-theme-standard-notes/blob/master/screenshot2.png"
+  <img src="https://github.com/Lissy93/callisto-theme-standard-notes/blob/master/screenshot2.png"
     alt="Screenshot of Authentication Screen"
     title="Screenshot of Authentication Screen"
     width="500"
@@ -21,7 +21,7 @@
 
 ## Installation
 
-**Installation Link**: `https://raw.githubusercontent.com/xthursdayx/callisto-theme-standard-notes/master/callisto-theme.json`
+**Installation Link**: `https://raw.githubusercontent.com/Lissy93/callisto-theme-standard-notes/master/callisto-theme.json`
 
 From the Standard Notes desktop app, go to Extensions (in the bottom left-hand corner), then Import Extension, paste the URL to the raw JSON file (see above) in, and hit enter, then when prompted click Install. You can now activate the theme, either from the extensions menu, or the theme switcher (lower left-hand corner in desktop, or the top of the draw menu on mobile).
 

--- a/callisto-theme.json
+++ b/callisto-theme.json
@@ -3,17 +3,17 @@ metatype: json
 ---
 
 {
-  "identifier": "io.github.xthursdayx.sn-callisto-theme",
+  "identifier": "io.github.Lissy93.sn-callisto-theme",
   "name": "Callisto",
   "content_type": "SN|Theme",
   "area": "themes",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Dusty background with teal accents",
-  "url": "https://raw.githubusercontent.com/xthursdayx/callisto-theme-standard-notes/master/dist/dist.css",
-  "download_url": "https://github.com/xthursdayx/callisto-theme-standard-notes/archive/1.0.2.zip",
-  "latest_url": "https://raw.githubusercontent.com/xthursdayx/callisto-theme-standard-notes/master/callisto.json",
-  "marketing_url": "https://github.com/xthursdayx/callisto-theme-standard-notes",
-  "thumbnail_url": "https://raw.githubusercontent.com/xthursdayx/callisto-theme-standard-notes/master/screenshot1.png",
+  "url": "https://raw.githubusercontent.com/Lissy93/callisto-theme-standard-notes/master/dist/dist.css",
+  "download_url": "https://github.com/Lissy93/callisto-theme-standard-notes/archive/1.0.3.zip",
+  "latest_url": "https://raw.githubusercontent.com/Lissy93/callisto-theme-standard-notes/master/callisto-theme.json",
+  "marketing_url": "https://github.com/Lissy93/callisto-theme-standard-notes",
+  "thumbnail_url": "https://raw.githubusercontent.com/Lissy93/callisto-theme-standard-notes/master/screenshot1.png",
 	"dock_icon": {
 	"type": "circle",
    	"background_color": "#0b1021",


### PR DESCRIPTION
Since I'll be deleting my fork, I switched all the links in the repo back to the correct `Lissy93/callisto-theme-standard-notes` URL.