### PR TITLE
Adapt theme CSS to new Standard Notes design

### DIFF
--- a/callisto-standard-notes.css
+++ b/callisto-standard-notes.css
@@ -50,17 +50,28 @@
   --sn-stylekit-secondary-contrast-background-color: var(--third-acsent);
   --sn-stylekit-secondary-contrast-foreground-color: var(--white);
   --sn-stylekit-secondary-contrast-border-color: var(--third-acsent);
-  --sn-stylekit-editor-background-color: var(--bg-color);
+  --sn-stylekit-editor-background-color: var(--bg-primary);
   --sn-stylekit-editor-foreground-color: var(--white);
   --sn-stylekit-paragraph-text-color: var(--white);
   --sn-stylekit-scrollbar-track-border-color: var(--very-dark-acsent);
   --sn-stylekit-scrollbar-thumb-color: var(--acsent);
+  --sn-stylekit-passive-color-3: var(--neutral);
+  --sn-stylekit-passive-color-5: var(--bg-darker);
+  --navigation-item-selected-background-color: var(--third-acsent);
 }
 
-// Fix for white color on notes in latest version
+/* Fix for white color on notes in latest version */
 #notes-column .note:hover, .notes .note:hover,
 #notes-column .note.selected, .notes .note.selected {
     background-color: var(--bg-darker);
     border-left: 3px solid #00af9a;
     transition: all 0.2s linear;
+}
+
+/* Fixes for white color on lockscreen in latest version */
+[data-reach-dialog-overlay]::before {
+  opacity: 1;
+}
+.mb-4.h-30.w-30 circle {
+  fill: #141b33;
 }


### PR DESCRIPTION
The latest version (at least since v3.23.83) of Standard Notes broke your adorable theme :(

In an attempt to fix, I made following changes:
- Fixed sn-stylekit-editor-background-color (there is no --bg-color variable in the stylesheet)
- Changed comment to [CSS-Syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Comments)
- Search box border a nuance darker
- Navigation purple again
- Darken lockscreen background & SVG

You may download my dev version to test:
https://raw.githubusercontent.com/pascalwei/callisto-theme-standard-notes/pascalwei-Callisto/callisto-theme.json

I made screenshots as well (new above, old below):
![changes](https://user-images.githubusercontent.com/103744505/188287598-de3db498-6e1c-42d5-b940-441bc113a205.png)

However I did not test those changes on other platforms such as listed, only in Notes.